### PR TITLE
Allow assets in collection field

### DIFF
--- a/src/FondOfSpryker/Zed/Contentful/Business/Storage/Collection/CollectionAssetField.php
+++ b/src/FondOfSpryker/Zed/Contentful/Business/Storage/Collection/CollectionAssetField.php
@@ -15,17 +15,12 @@ class CollectionAssetField implements CollectionFieldInterface
         $this->asset = $asset;
     }
 
-    public function getFileUrl()
-    {
-        return $this->asset->getFile()->getUrl();
-    }
-
     public function getAsset()
     {
         return [
             'title' => $this->asset->getTitle(),
             'description' => $this->asset->getDescription(),
-            'url' => $this->getFileUrl(),
+            'url' => $this->asset->getFile()->getUrl(),
         ];
     }
 

--- a/src/FondOfSpryker/Zed/Contentful/Business/Storage/Collection/CollectionAssetField.php
+++ b/src/FondOfSpryker/Zed/Contentful/Business/Storage/Collection/CollectionAssetField.php
@@ -8,14 +8,23 @@ class CollectionAssetField implements CollectionFieldInterface
 {
     public const TYPE = 'Asset';
 
+    /**
+     * var Asset
+     */
     private $asset;
 
+    /**
+     * @param \Contentful\Delivery\Resource\Asset $asset
+     */
     public function __construct(Asset $asset)
     {
         $this->asset = $asset;
     }
 
-    public function getAsset()
+    /**
+     * @return string[]
+     */
+    public function getAsset(): array
     {
         return [
             'title' => $this->asset->getTitle(),
@@ -25,7 +34,7 @@ class CollectionAssetField implements CollectionFieldInterface
     }
 
     /**
-     * @inheritDoc
+     * @return string
      */
     public function getType(): string
     {
@@ -33,9 +42,9 @@ class CollectionAssetField implements CollectionFieldInterface
     }
 
     /**
-     * @inheritDoc
+     * @return mixed[]
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'type' => $this->getType(),

--- a/src/FondOfSpryker/Zed/Contentful/Business/Storage/Collection/CollectionAssetField.php
+++ b/src/FondOfSpryker/Zed/Contentful/Business/Storage/Collection/CollectionAssetField.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace FondOfSpryker\Zed\Contentful\Business\Storage\Collection;
+
+use Contentful\Delivery\Resource\Asset;
+
+class CollectionAssetField implements CollectionFieldInterface
+{
+    public const TYPE = 'Asset';
+
+    private $asset;
+
+    public function __construct(Asset $asset)
+    {
+        $this->asset = $asset;
+    }
+
+    public function getFileUrl()
+    {
+        return $this->asset->getFile()->getUrl();
+    }
+
+    public function getAsset()
+    {
+        return [
+            'title' => $this->asset->getTitle(),
+            'description' => $this->asset->getDescription(),
+            'url' => $this->getFileUrl(),
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string
+    {
+        return static::TYPE;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'type' => $this->getType(),
+            'value' => $this->getAsset(),
+        ];
+    }
+}

--- a/src/FondOfSpryker/Zed/Contentful/Business/Storage/Collection/CollectionAssetField.php
+++ b/src/FondOfSpryker/Zed/Contentful/Business/Storage/Collection/CollectionAssetField.php
@@ -9,7 +9,7 @@ class CollectionAssetField implements CollectionFieldInterface
     public const TYPE = 'Asset';
 
     /**
-     * var Asset
+     * var \Contentful\Delivery\Resource\Asset
      */
     private $asset;
 

--- a/src/FondOfSpryker/Zed/Contentful/Business/Storage/Collection/CollectionFieldMapper.php
+++ b/src/FondOfSpryker/Zed/Contentful/Business/Storage/Collection/CollectionFieldMapper.php
@@ -2,6 +2,7 @@
 
 namespace FondOfSpryker\Zed\Contentful\Business\Storage\Collection;
 
+use Contentful\Delivery\Resource\Asset;
 use FondOfSpryker\Zed\Contentful\Business\Client\Entry\ContentfulEntryInterface;
 use FondOfSpryker\Zed\Contentful\Business\Client\Field\ContentfulField;
 use FondOfSpryker\Zed\Contentful\Business\Client\Field\ContentfulFieldInterface;
@@ -38,6 +39,11 @@ class CollectionFieldMapper implements TypeFieldMapperInterface
         foreach ($fieldValues as $fieldValue) {
             if ($fieldValue instanceof ContentfulEntryInterface && $contentfulField->getItemsLinkType() === ContentfulField::FIELD_TYPE_ENTRY) {
                 $field->addField(new CollectionReferenceField($fieldValue->getId()));
+                continue;
+            }
+
+            if ($fieldValue instanceof Asset && $contentfulField->getItemsLinkType() === ContentfulField::FIELD_TYPE_ASSET) {
+                $field->addField(new CollectionAssetField($fieldValue));
                 continue;
             }
 


### PR DESCRIPTION
This resolves an issue where the Contentful importer fails when the CollectionField includes Contentful assets.

The new class will translate the Contentful asset to:

```json
"type": "Asset",
"value": {
  "title": null,
  "description": null,
  "url": null
}
```