### PR TITLE
feat: add brand tag filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "fond-of-codeception/spryker": "^1.0",
-    "spryker/code-sniffer": "*",
+    "spryker/code-sniffer": "^0.16.0",
     "spryker-sdk/phpstan-spryker": "*"
   },
   "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,4 @@ parameters:
     ignoreErrors:
         - '#.* on an unknown class Generated\\(Client|Glue|Service|Yves|Zed)\\.*#'
         - '#.*\\ContentfulPageSearch\\.*#'
+        - '#Constant APPLICATION_STORE not found.#'

--- a/src/FondOfSpryker/Zed/Contentful/Business/Client/ContentfulAPIClient.php
+++ b/src/FondOfSpryker/Zed/Contentful/Business/Client/ContentfulAPIClient.php
@@ -24,12 +24,23 @@ class ContentfulAPIClient implements ContentfulAPIClientInterface
     }
 
     /**
+     * @return string
+     */
+    protected function getBrand(): string
+    {
+        $storePieces = explode('_', APPLICATION_STORE);
+
+        return strtolower($storePieces[0]);
+    }
+
+    /**
      * @return \Contentful\Core\Resource\ResourceArray
      */
     public function findLastChangedEntries(): ResourceArray
     {
         $query = new Query();
         $query->where('sys.updatedAt[gte]', (new DateTime())->modify('-10 minutes'));
+        $query->where('metadata.tags.sys.id[in]', $this->getBrand());
         $query->setLimit(1000);
         $query->setLocale('*');
 
@@ -45,6 +56,7 @@ class ContentfulAPIClient implements ContentfulAPIClientInterface
     {
         $query = new Query();
         $query->where('sys.id[match]', $entryId);
+        $query->where('metadata.tags.sys.id[in]', $this->getBrand());
         $query->setLimit(10);
         $query->setLocale('*');
 
@@ -60,6 +72,7 @@ class ContentfulAPIClient implements ContentfulAPIClientInterface
     {
         $query = new Query();
         $query->where('sys.createdAt[gte]', new DateTime('2010-01-01 00:00:00'));
+        $query->where('metadata.tags.sys.id[in]', $this->getBrand());
         $query->setLimit(1000);
         $query->setLocale('*');
 


### PR DESCRIPTION
This pull request adds brand-based filtering to Contentful API queries in the `ContentfulAPIClient` class. Now, entries are filtered by a brand tag derived from the current store, ensuring that only relevant data for the active brand is retrieved.

**Brand filtering enhancements:**

* Added a protected `getBrand()` method to extract the brand name from the `APPLICATION_STORE` constant and format it for query usage.
* Updated `findLastChangedEntries()` to filter results by brand using the `metadata.tags.sys.id[in]` query parameter.
* Updated `findEntryById()` to include brand filtering in its query.
* Updated `findAllEntries()` to filter all entries by brand tag.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211020218466727